### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ onMounted(() => {
   handleFetchTeam();
 });
 </script>
-
+```
 This package require to use [laravel-permission](https://github.com/spatie/laravel-permission)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -38,6 +38,39 @@ After installed you can do like this in [Vuejs](https://vuejs.org/):
   <!-- Do something -->
 </div>
 ```
+## Using `can` and `is` Methods in Vue 3 Setup Script
+
+To utilize the `can` and `is` methods provided by the `laravel-permission-to-vuejs` plugin in a Vue 3 setup script, follow the steps below:
+
+### Example
+
+```html
+<template>
+  <!-- Your component template -->
+</template>
+
+<script setup>
+import { getCurrentInstance } from 'vue';
+
+const { appContext } = getCurrentInstance();
+const globalProperties = appContext.config.globalProperties;
+
+const handleFetchTeam = () => {
+  if (globalProperties.is('someRole')) {
+    console.log('User has the role');
+    // Your logic here
+  } else {
+    console.log('User does not have the role');
+    // Handle case where user does not have the required role
+  }
+};
+
+// Call the function on component mount or any other lifecycle hook as needed
+onMounted(() => {
+  handleFetchTeam();
+});
+</script>
+
 This package require to use [laravel-permission](https://github.com/spatie/laravel-permission)
 
 ## Installation


### PR DESCRIPTION
Issue: Accessing `is` and `can` Methods from `laravel-permission-to-vue.js` in Vue 3 Setup Script

Problem
When trying to access the `is` and `can` methods from the `laravel-permission-to-vue.js` plugin in the Vue 3 setup script, a `ReferenceError` was encountered. This error occurred because the methods were not being accessed correctly from the global properties.

Error Message

ReferenceError: is is not defined
    at handleFetchTeam (TopBar.vue:210:5)
    at TopBar.vue:294:5
    at runtime-core.esm-bundler.js:2884:88
    at callWithErrorHandling (runtime-core.esm-bundler.js:195:19)
    at callWithAsyncErrorHandling (runtime-core.esm-bundler.js:202:17)
    at hook.__weh.hook.__weh (runtime-core.esm-bundler.js:2864:19)
    at flushPostFlushCbs (runtime-core.esm-bundler.js:378:40)
    at flushJobs (runtime-core.esm-bundler.js:416:5)


Solution
To resolve this issue, the `is` and `can` methods are now accessed using the `getCurrentInstance` method provided by Vue 3. This ensures that the global properties are correctly referenced within the setup script.