### PR TITLE
Make reloadRolesAndPermissions Asynchronous to Ensure Correct Permission Loading

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -52,8 +52,8 @@ class LaravelPermissionToVue
 		return _return
 	}
 
-	reloadRolesAndPermissions = function(route = '/get-laravel-permission-to-vuejs'){
-		axios.get(route).then(
+	reloadRolesAndPermissions = async function(route = '/get-laravel-permission-to-vuejs'){
+		await axios.get(route).then(
 		  response => {
 		    window.Laravel.jsPermissions = response.data
 		  }


### PR DESCRIPTION
Made reloadRolesAndPermissions asynchronous because it contains an Axios request. Without this, there is a risk that permissions may not be reloaded in time when the page loads, causing the component to load without the correct permissions.

Hope you find this usefull.
Thanks,
Tommaso.